### PR TITLE
Optimize image, reduce docker image size by 11GB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV DOCKER_ANDROID_DISPLAY_NAME mobileci-docker
 ENV DEBIAN_FRONTEND noninteractive
 
 # Update apt-get
-RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get update
 RUN apt-get dist-upgrade -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,10 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get clean
 
 # Install Android SDK
-RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
-RUN tar -xvzf android-sdk_r24.4.1-linux.tgz
-RUN mv android-sdk-linux /usr/local/android-sdk
-RUN rm android-sdk_r24.4.1-linux.tgz
+RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \
+  && tar -xvzf android-sdk_r24.4.1-linux.tgz \
+  && mv android-sdk-linux /usr/local/android-sdk \
+  && rm android-sdk_r24.4.1-linux.tgz
 
 ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,23 +60,6 @@ RUN apt-add-repository ppa:openjdk-r/ppa \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Android SDK
-RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \
-  && tar -xvzf android-sdk_r24.4.1-linux.tgz \
-  && mv android-sdk-linux /usr/local/android-sdk \
-  && rm android-sdk_r24.4.1-linux.tgz
-
-ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0
-
-# Install Android tools
-RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a
-
-# Install Android NDK
-RUN wget http://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip \
-  && unzip android-ndk-r12-linux-x86_64.zip \
-  && mv android-ndk-r12 /usr/local/android-ndk \
-  && rm android-ndk-r12-linux-x86_64.zip
-
 # Environment variables
 ENV ANDROID_HOME /usr/local/android-sdk
 ENV ANDROID_SDK_HOME $ANDROID_HOME
@@ -92,11 +75,6 @@ ENV PATH $PATH:$ANDROID_NDK_HOME
 # Export JAVA_HOME variable
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
-# Support Gradle
-ENV TERM dumb
-ENV JAVA_OPTS "-Xms4096m -Xmx4096m"
-ENV GRADLE_OPTS "-XX:+UseG1GC -XX:MaxGCPauseMillis=1000"
-
 # Add build user account, values are set to default below
 ENV RUN_USER mobileci
 ENV RUN_UID 5089
@@ -107,9 +85,33 @@ RUN id $RUN_USER || adduser --uid "$RUN_UID" \
     --disabled-login \
     --disabled-password "$RUN_USER"
 
-# Fix permissions
-RUN chown -R $RUN_USER:$RUN_USER $ANDROID_HOME $ANDROID_SDK_HOME $ANDROID_NDK_HOME
-RUN chmod -R a+rx $ANDROID_HOME $ANDROID_SDK_HOME $ANDROID_NDK_HOME
+# Install Android SDK
+RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \
+  && tar -xvzf android-sdk_r24.4.1-linux.tgz \
+  && mv android-sdk-linux /usr/local/android-sdk \
+  && chown -R $RUN_USER:$RUN_USER $ANDROID_HOME \
+  && chmod -R a+rx $ANDROID_HOME \
+  && rm android-sdk_r24.4.1-linux.tgz
+
+ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0
+
+# Install Android tools
+RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a \
+  && chown -R $RUN_USER:$RUN_USER $ANDROID_HOME \
+  && chmod -R a+rx $ANDROID_HOME
+
+# Install Android NDK
+RUN wget http://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip \
+  && unzip android-ndk-r12-linux-x86_64.zip \
+  && mv android-ndk-r12 /usr/local/android-ndk \
+  && chown -R $RUN_USER:$RUN_USER $ANDROID_NDK_HOME \
+  && chmod -R a+rx $ANDROID_NDK_HOME \
+  && rm android-ndk-r12-linux-x86_64.zip
+
+# Support Gradle
+ENV TERM dumb
+ENV JAVA_OPTS "-Xms4096m -Xmx4096m"
+ENV GRADLE_OPTS "-XX:+UseG1GC -XX:MaxGCPauseMillis=1000"
 
 # Creating project directories prepared for build when running
 # `docker run`

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,53 +14,51 @@ ENV DOCKER_ANDROID_DISPLAY_NAME mobileci-docker
 # Never ask for confirmations
 ENV DEBIAN_FRONTEND noninteractive
 
-# Update apt-get
-RUN apt-get update
-RUN apt-get dist-upgrade -y
-
-# Installing packages
-RUN apt-get install -y \
-  autoconf \
-  build-essential \
-  bzip2 \
-  curl \
-  gcc \
-  git \
-  groff \
-  lib32stdc++6 \
-  lib32z1 \
-  lib32z1-dev \
-  lib32ncurses5 \
-  lib32bz2-1.0 \
-  libc6-dev \
-  libgmp-dev \
-  libmpc-dev \
-  libmpfr-dev \
-  libxslt-dev \
-  libxml2-dev \
-  m4 \
-  make \
-  ncurses-dev \
-  ocaml \
-  openssh-client \
-  pkg-config \
-  python-software-properties \
-  rsync \
-  software-properties-common \
-  unzip \
-  wget \
-  zip \
-  zlib1g-dev \
-  --no-install-recommends
+# Updating & Installing packages
+RUN apt-get update \
+  && apt-get dist-upgrade -y \
+  && apt-get install -y \
+    autoconf \
+    build-essential \
+    bzip2 \
+    curl \
+    gcc \
+    git \
+    groff \
+    lib32stdc++6 \
+    lib32z1 \
+    lib32z1-dev \
+    lib32ncurses5 \
+    lib32bz2-1.0 \
+    libc6-dev \
+    libgmp-dev \
+    libmpc-dev \
+    libmpfr-dev \
+    libxslt-dev \
+    libxml2-dev \
+    m4 \
+    make \
+    ncurses-dev \
+    ocaml \
+    openssh-client \
+    pkg-config \
+    python-software-properties \
+    rsync \
+    software-properties-common \
+    unzip \
+    wget \
+    zip \
+    zlib1g-dev \
+    --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Java
-RUN apt-add-repository ppa:openjdk-r/ppa
-RUN apt-get update
-RUN apt-get -y install openjdk-8-jdk
-
-# Clean Up Apt-get
-RUN rm -rf /var/lib/apt/lists/*
-RUN apt-get clean
+RUN apt-add-repository ppa:openjdk-r/ppa \
+  && apt-get update \
+  && apt-get -y install openjdk-8-jdk \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Android SDK
 RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,10 +75,10 @@ ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a
 
 # Install Android NDK
-RUN wget http://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip
-RUN unzip android-ndk-r12-linux-x86_64.zip
-RUN mv android-ndk-r12 /usr/local/android-ndk
-RUN rm android-ndk-r12-linux-x86_64.zip
+RUN wget http://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip \
+  && unzip android-ndk-r12-linux-x86_64.zip \
+  && mv android-ndk-r12 /usr/local/android-ndk \
+  && rm android-ndk-r12-linux-x86_64.zip
 
 # Environment variables
 ENV ANDROID_HOME /usr/local/android-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,9 +97,6 @@ ENV TERM dumb
 ENV JAVA_OPTS "-Xms4096m -Xmx4096m"
 ENV GRADLE_OPTS "-XX:+UseG1GC -XX:MaxGCPauseMillis=1000"
 
-# Cleaning
-RUN apt-get clean
-
 # Add build user account, values are set to default below
 ENV RUN_USER mobileci
 ENV RUN_UID 5089


### PR DESCRIPTION
The changes only consist of structural changes,
the build environment itself has not been altered.

What has been achieved by the changes:
 - much faster build time from 33min to 5.5min (600% faster) (build-time depends on network and IO perfomance)
 - reduces image size from 16.1GB to 5.14GB (>300% smaller)
 - reduces image layers  from 52 to 36

Clear `/var/lib/apt/lists/` in the same layer `apt-get update` was invoked:
https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run

Optimize for image size:
https://blog.replicated.com/engineering/refactoring-a-dockerfile-for-image-size/

![screenshot](https://cloud.githubusercontent.com/assets/7721625/23900404/6aaa6148-08b9-11e7-9c98-aeccac0c9c70.png)
