### PR TITLE
Upgrading versions to support Android Studio Instant Run feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
   - docker
 
 script:
-  - docker build --quiet=true -t uber/android-build-environment .
+  - docker build --quiet=true -t alrosot/android-build-environment .

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \
   && chmod -R a+rx $ANDROID_HOME \
   && rm android-sdk_r24.4.1-linux.tgz
 
-ENV ANDROID_COMPONENTS platform-tools,android-24,build-tools-25.0.2,extra-android-m2repository
+ENV ANDROID_COMPONENTS platform-tools,android-24,build-tools-25.0.2,extra-android-m2repository,extra-google-m2repository
 
 # Install Android tools
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN tar -xvzf android-sdk_r24.4.1-linux.tgz
 RUN mv android-sdk-linux /usr/local/android-sdk
 RUN rm android-sdk_r24.4.1-linux.tgz
 
-ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0
+ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0,build-tools-25.0.2,android-24
 
 # Install Android tools
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,71 +14,51 @@ ENV DOCKER_ANDROID_DISPLAY_NAME mobileci-docker
 # Never ask for confirmations
 ENV DEBIAN_FRONTEND noninteractive
 
-# Update apt-get
-RUN rm -rf /var/lib/apt/lists/*
-RUN apt-get update
-RUN apt-get dist-upgrade -y
-
-# Installing packages
-RUN apt-get install -y \
-  autoconf \
-  build-essential \
-  bzip2 \
-  curl \
-  gcc \
-  git \
-  groff \
-  lib32stdc++6 \
-  lib32z1 \
-  lib32z1-dev \
-  lib32ncurses5 \
-  lib32bz2-1.0 \
-  libc6-dev \
-  libgmp-dev \
-  libmpc-dev \
-  libmpfr-dev \
-  libxslt-dev \
-  libxml2-dev \
-  m4 \
-  make \
-  ncurses-dev \
-  ocaml \
-  openssh-client \
-  pkg-config \
-  python-software-properties \
-  rsync \
-  software-properties-common \
-  unzip \
-  wget \
-  zip \
-  zlib1g-dev \
-  --no-install-recommends
+# Updating & Installing packages
+RUN apt-get update \
+  && apt-get dist-upgrade -y \
+  && apt-get install -y \
+    autoconf \
+    build-essential \
+    bzip2 \
+    curl \
+    gcc \
+    git \
+    groff \
+    lib32stdc++6 \
+    lib32z1 \
+    lib32z1-dev \
+    lib32ncurses5 \
+    lib32bz2-1.0 \
+    libc6-dev \
+    libgmp-dev \
+    libmpc-dev \
+    libmpfr-dev \
+    libxslt-dev \
+    libxml2-dev \
+    m4 \
+    make \
+    ncurses-dev \
+    ocaml \
+    openssh-client \
+    pkg-config \
+    python-software-properties \
+    rsync \
+    software-properties-common \
+    unzip \
+    wget \
+    zip \
+    zlib1g-dev \
+    --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Java
-RUN apt-add-repository ppa:openjdk-r/ppa
-RUN apt-get update
-RUN apt-get -y install openjdk-8-jdk
-
-# Clean Up Apt-get
-RUN rm -rf /var/lib/apt/lists/*
-RUN apt-get clean
-
-# Install Android SDK
-RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
-RUN tar -xvzf android-sdk_r24.4.1-linux.tgz
-RUN mv android-sdk-linux /usr/local/android-sdk
-RUN rm android-sdk_r24.4.1-linux.tgz
-
-ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0,build-tools-25.0.2,android-24
-
-# Install Android tools
-RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a
-
-# Install Android NDK
-RUN wget http://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip
-RUN unzip android-ndk-r12-linux-x86_64.zip
-RUN mv android-ndk-r12 /usr/local/android-ndk
-RUN rm android-ndk-r12-linux-x86_64.zip
+RUN apt-add-repository ppa:openjdk-r/ppa \
+  && apt-get update \
+  && apt-get -y install openjdk-8-jdk \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Environment variables
 ENV ANDROID_HOME /usr/local/android-sdk
@@ -95,14 +75,6 @@ ENV PATH $PATH:$ANDROID_NDK_HOME
 # Export JAVA_HOME variable
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
-# Support Gradle
-ENV TERM dumb
-ENV JAVA_OPTS "-Xms4096m -Xmx4096m"
-ENV GRADLE_OPTS "-XX:+UseG1GC -XX:MaxGCPauseMillis=1000"
-
-# Cleaning
-RUN apt-get clean
-
 # Add build user account, values are set to default below
 ENV RUN_USER mobileci
 ENV RUN_UID 5089
@@ -113,9 +85,33 @@ RUN id $RUN_USER || adduser --uid "$RUN_UID" \
     --disabled-login \
     --disabled-password "$RUN_USER"
 
-# Fix permissions
-RUN chown -R $RUN_USER:$RUN_USER $ANDROID_HOME $ANDROID_SDK_HOME $ANDROID_NDK_HOME
-RUN chmod -R a+rx $ANDROID_HOME $ANDROID_SDK_HOME $ANDROID_NDK_HOME
+# Install Android SDK
+RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \
+  && tar -xvzf android-sdk_r24.4.1-linux.tgz \
+  && mv android-sdk-linux /usr/local/android-sdk \
+  && chown -R $RUN_USER:$RUN_USER $ANDROID_HOME \
+  && chmod -R a+rx $ANDROID_HOME \
+  && rm android-sdk_r24.4.1-linux.tgz
+
+ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0
+
+# Install Android tools
+RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a \
+  && chown -R $RUN_USER:$RUN_USER $ANDROID_HOME \
+  && chmod -R a+rx $ANDROID_HOME
+
+# Install Android NDK
+RUN wget http://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip \
+  && unzip android-ndk-r12-linux-x86_64.zip \
+  && mv android-ndk-r12 /usr/local/android-ndk \
+  && chown -R $RUN_USER:$RUN_USER $ANDROID_NDK_HOME \
+  && chmod -R a+rx $ANDROID_NDK_HOME \
+  && rm android-ndk-r12-linux-x86_64.zip
+
+# Support Gradle
+ENV TERM dumb
+ENV JAVA_OPTS "-Xms4096m -Xmx4096m"
+ENV GRADLE_OPTS "-XX:+UseG1GC -XX:MaxGCPauseMillis=1000"
 
 # Creating project directories prepared for build when running
 # `docker run`

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \
   && chmod -R a+rx $ANDROID_HOME \
   && rm android-sdk_r24.4.1-linux.tgz
 
-ENV ANDROID_COMPONENTS platform-tools,android-23,build-tools-23.0.2,build-tools-24.0.0
+ENV ANDROID_COMPONENTS platform-tools,android-24,build-tools-25.0.2
 
 # Install Android tools
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a \

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz \
   && chmod -R a+rx $ANDROID_HOME \
   && rm android-sdk_r24.4.1-linux.tgz
 
-ENV ANDROID_COMPONENTS platform-tools,android-24,build-tools-25.0.2
+ENV ANDROID_COMPONENTS platform-tools,android-24,build-tools-25.0.2,extra-android-m2repository
 
 # Install Android tools
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,11 @@ ENV DOCKER_ANDROID_DISPLAY_NAME mobileci-docker
 ENV DEBIAN_FRONTEND noninteractive
 
 # Updating & Installing packages
-RUN apt-get update \
-  && apt-get dist-upgrade -y \
-  && apt-get install -y \
+RUN apt-get update && apt-get install -y \
+    wget \
     autoconf \
     build-essential \
     bzip2 \
-    curl \
-    gcc \
-    git \
     groff \
     lib32stdc++6 \
     lib32z1 \
@@ -46,7 +42,6 @@ RUN apt-get update \
     rsync \
     software-properties-common \
     unzip \
-    wget \
     zip \
     zlib1g-dev \
     --no-install-recommends \
@@ -63,14 +58,12 @@ RUN apt-add-repository ppa:openjdk-r/ppa \
 # Environment variables
 ENV ANDROID_HOME /usr/local/android-sdk
 ENV ANDROID_SDK_HOME $ANDROID_HOME
-ENV ANDROID_NDK_HOME /usr/local/android-ndk
 ENV JENKINS_HOME $HOME
 ENV PATH ${INFER_HOME}/bin:${PATH}
 ENV PATH $PATH:$ANDROID_SDK_HOME/tools
 ENV PATH $PATH:$ANDROID_SDK_HOME/platform-tools
 ENV PATH $PATH:$ANDROID_SDK_HOME/build-tools/23.0.2
 ENV PATH $PATH:$ANDROID_SDK_HOME/build-tools/24.0.0
-ENV PATH $PATH:$ANDROID_NDK_HOME
 
 # Export JAVA_HOME variable
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
@@ -99,14 +92,6 @@ ENV ANDROID_COMPONENTS platform-tools,android-24,build-tools-25.0.2,extra-androi
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter "${ANDROID_COMPONENTS}" --no-ui -a \
   && chown -R $RUN_USER:$RUN_USER $ANDROID_HOME \
   && chmod -R a+rx $ANDROID_HOME
-
-# Install Android NDK
-RUN wget http://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip \
-  && unzip android-ndk-r12-linux-x86_64.zip \
-  && mv android-ndk-r12 /usr/local/android-ndk \
-  && chown -R $RUN_USER:$RUN_USER $ANDROID_NDK_HOME \
-  && chmod -R a+rx $ANDROID_NDK_HOME \
-  && rm android-ndk-r12-linux-x86_64.zip
 
 # Support Gradle
 ENV TERM dumb

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://images.microbadger.com/badges/image/alrosot/android-build-environment.svg)](https://microbadger.com/images/alrosot/android-build-environment "Get your own image badge on microbadger.com")
+
 Android Build on Docker Container
 ===
 

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Then connect to your VPN and restart the docker vm:
 	$ docker-machine start default
 	$ eval "$(docker-machine env default)"
 
-[Read more](http://olympia.readthedocs.org/en/latest/topics/development/vpn.html)
+


### PR DESCRIPTION
Android Studio Instant run is quite an useful feature in development environments. But that requires a version bump on gradle and on build-tools